### PR TITLE
fix: formatter throws error Unhandled method textDocument/formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "contributors": [
     "Steve Korshakov (ex3ndr) <steve@korshakov.com>",
     "XTON crypto wallet team <askme@xtonwallet.com>"
+	"TONK Finance (defi-pickle) <team@tonk.finance>"
   ],
   "bugs": {
     "url": "https://github.com/tact-lang/tact-vscode/issues"

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   ],
   "contributors": [
     "Steve Korshakov (ex3ndr) <steve@korshakov.com>",
-    "XTON crypto wallet team <askme@xtonwallet.com>"
-	"TONK Finance (defi-pickle) <team@tonk.finance>"
+    "XTON crypto wallet team <askme@xtonwallet.com>",
+    "TONK Finance (defi-pickle) <team@tonk.finance>"
   ],
   "bugs": {
     "url": "https://github.com/tact-lang/tact-vscode/issues"

--- a/src/server.ts
+++ b/src/server.ts
@@ -213,7 +213,6 @@ connection.onInitialize((result): InitializeResult => {
             codeActionProvider: {
                 resolveProvider: true
             },
-            documentFormattingProvider: true,
             textDocumentSync: TextDocumentSyncKind.Full,
         },
     };


### PR DESCRIPTION
Related to the issue https://github.com/tact-lang/tact-vscode/issues/3

There is probably something wrong with this bit: 
```
    context.subscriptions.push(
        languages.registerDocumentFormattingEditProvider('tact', {
            provideDocumentFormattingEdits(document: TextDocument, options: FormattingOptions, token: CancellationToken): ProviderResult<TextEdit[]> {
                return Promise.resolve(formatDocument(document, context));
            },
    }));
```
Something is not right with `formatDocument`. If you want i can try to fix that later but this might be enough to get you started. 

source: https://code.visualstudio.com/api/language-extensions/programmatic-language-features#format-source-code-in-an-editor