### PR TITLE
Add support for @stdlib imports for syntax highlighting (Issue #51)

### DIFF
--- a/src/model/contract.ts
+++ b/src/model/contract.ts
@@ -1,12 +1,13 @@
 'use strict';
 import * as path from 'path';
+import * as fs from 'fs';
 import { formatPath } from '../util';
 
 export class Contract {
     public code: string;
-    // TODO: Import needs to be a class including if is local, absolutePath, module etc
     public imports: Array<string>;
     public absolutePath: string;
+
     constructor(absoulePath: string, code: string) {
         this.absolutePath = this.formatContractPath(absoulePath);
         this.code = code;
@@ -24,12 +25,21 @@ export class Contract {
     public resolveImports() {
         const importRegEx = /^\s?import\s+[^'"]*['"](.*)['"]\s*/gm;
         let foundImport = importRegEx.exec(this.code);
+
         while (foundImport != null) {
             const importPath = foundImport[1];
-
+            
             if (this.isImportLocal(importPath)) {
                 const importFullPath = this.formatContractPath(path.resolve(path.dirname(this.absolutePath), foundImport[1]));
                 this.imports.push(importFullPath);
+            } else if (importPath.startsWith('@stdlib/')) {
+                const stdlibPath = path.resolve(path.dirname(this.absolutePath), "../node_modules/@tact-lang/compiler/stdlib");
+                const contractFileName = importPath.replace('@stdlib/', '') + '.tact';
+                const contractFullPath = path.join(stdlibPath, 'libs', contractFileName);
+
+                if (fs.existsSync(contractFullPath)) {
+                    this.imports.push(contractFullPath);
+                }
             } else {
                 this.imports.push(importPath);
             }


### PR DESCRIPTION
This PR resolves issue 
https://github.com/tact-lang/tact-vscode/issues/51 by adding support for @stdlib imports in the resolveImports method. Imports like @stdlib/deploy and @stdlib/ownable are now correctly resolved to paths in the node_modules/@tact-lang/compiler/stdlib/libs directory, enabling syntax highlighting and other IDE features.

Changes:
Updated resolveImports to handle @stdlib imports.

Testing: Verified that @stdlib imports are correctly recognized and syntax highlighting works as expected.
