### PR TITLE
chore: add deprecation notice to description and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+> !NOTE
+> 
+> This extension has been deprecated 
+> in favor of https://marketplace.visualstudio.com/items?itemName=tonstudio.vscode-tact
+
 # Tact language support for Visual Studio code
 
 <div align="center">

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> !NOTE
+> [!NOTE]
 > 
 > This extension has been deprecated 
 > in favor of https://marketplace.visualstudio.com/items?itemName=tonstudio.vscode-tact

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "tact-lang-vscode",
   "displayName": "Tact Language Support for TON blockchain",
-  "description": "Tact language (for .tact file) extension to use together with Tact compiler for Visual Studio Code to develop smart contract for TON blockchain",
+  "description": "(deprecated) Tact language (for .tact file) extension to use together with Tact compiler for Visual Studio Code to develop smart contract for TON blockchain",
   "publisher": "KonVik",
   "icon": "icons/logo.png",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "keywords": [
     "tact",
     "blockchain",


### PR DESCRIPTION
We've been getting a lot of questions lately about which Tact extension to use. Since the [official extension](https://marketplace.visualstudio.com/items?itemName=tonstudio.vscode-tact) is growing more and more, we recommend using it. 

You have put a lot of effort into your extension, but it is not developing :(

It would be nice if we added a description that this extension is deprecated so as not to confuse new users who come to Tact

Thank you!
